### PR TITLE
Fix DoH base64 encoding

### DIFF
--- a/doh.go
+++ b/doh.go
@@ -66,8 +66,7 @@ func (c DoHClient) Query(ctx context.Context, msg *dns.Msg) ([]dns.RR, time.Dura
 		return []dns.RR{}, time.Since(start), err
 	}
 	// convert to base64
-	dohbase64 := base64.StdEncoding.EncodeToString(dohbytes)
-	dohbase64 = strings.TrimRight(dohbase64, "=")
+	dohbase64 := base64.URLEncoding.EncodeToString(dohbytes)
 	q := c.req.URL.Query()
 	q.Set("dns", dohbase64)
 	c.req.URL.RawQuery = q.Encode()

--- a/doh.go
+++ b/doh.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"io/ioutil"
 	"net"
+	"strings"
 	"time"
 
 	"net/http"
@@ -66,6 +67,7 @@ func (c DoHClient) Query(ctx context.Context, msg *dns.Msg) ([]dns.RR, time.Dura
 	}
 	// convert to base64
 	dohbase64 := base64.URLEncoding.EncodeToString(dohbytes)
+	dohbase64 = strings.TrimRight(dohbase64, "=")
 	q := c.req.URL.Query()
 	q.Set("dns", dohbase64)
 	c.req.URL.RawQuery = q.Encode()

--- a/doh.go
+++ b/doh.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"io/ioutil"
 	"net"
-	"strings"
 	"time"
 
 	"net/http"

--- a/doh.go
+++ b/doh.go
@@ -67,7 +67,7 @@ func (c DoHClient) Query(ctx context.Context, msg *dns.Msg) ([]dns.RR, time.Dura
 	}
 	// convert to base64
 	dohbase64 := base64.StdEncoding.EncodeToString(dohbytes)
-	dohbase64 = strings.TrimSuffix(dohbase64, "=")
+	dohbase64 = strings.TrimRight(dohbase64, "=")
 	q := c.req.URL.Query()
 	q.Set("dns", dohbase64)
 	c.req.URL.RawQuery = q.Encode()


### PR DESCRIPTION
Thanks for your awesome package.
I'm trying to debug the problem I have with your sniproxy and I ended up with using DoH, but I see that `TrimSuffix` can't actually trim `=`s if there are more than one, but `TrimRight` does.
Please make sure that I'm not wrong about it and please accept this small PR if I'm right.
Thanks